### PR TITLE
Fixed voucher FULL_PATH constants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
     <minor-version>13</minor-version>
-    <patch-version>2</patch-version>
+    <patch-version>3</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,14 @@
 This page describes changes to the Airtime Service Interface implemented across different releases of the interface.
 
+## v5.13.3
+
+Released 13 May 2020
+
+- Fixed the `FULL_PATH` constants for `Vouchers` resource operations. The following constants were corrected:
+    - `VouchersResource.ConfirmVoucher.FULL_PATH`
+    - `VouchersResource.ProvisionVoucher.FULL_PATH`
+    - `VouchersResource.ReverseVoucher.FULL_PATH`
+
 ## v5.13.2
 
 Released 28 November 2019

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -2,12 +2,14 @@ This page describes changes to the Airtime Service Interface implemented across 
 
 ## v5.13.3
 
-Released 13 May 2020
+Released 12 May 2020
 
-- Fixed the `FULL_PATH` constants for `Vouchers` resource operations. The following constants were corrected:
-    - `VouchersResource.ConfirmVoucher.FULL_PATH`
-    - `VouchersResource.ProvisionVoucher.FULL_PATH`
-    - `VouchersResource.ReverseVoucher.FULL_PATH`
+- Fixed the `FULL_PATH` constants for `Vouchers` resource operations.
+    - Note, this change is a breaking change for the Java implementation of the API provided by Electrum.
+    - The following constants were corrected to no longer reference the `MSISDN` resource, and now reference the `Voucher` resource:
+        - `VouchersResource.ConfirmVoucher.FULL_PATH`
+        - `VouchersResource.ProvisionVoucher.FULL_PATH`
+        - `VouchersResource.ReverseVoucher.FULL_PATH`
 
 ## v5.13.2
 

--- a/src/main/java/io/electrum/airtime/api/VouchersResource.java
+++ b/src/main/java/io/electrum/airtime/api/VouchersResource.java
@@ -46,7 +46,7 @@ public abstract class VouchersResource {
       public static final String PATH =
             "/{" + PathParameters.REQUEST_ID + "}/confirmations/{" + PathParameters.CONFIRMATION_ID + "}";
       public static final String RELATIVE_PATH = PATH;
-      public static final String FULL_PATH = MsisdnResource.PATH + RELATIVE_PATH;
+      public static final String FULL_PATH = VouchersResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String CONFIRMATION_ID = "confirmationId";
@@ -59,7 +59,7 @@ public abstract class VouchersResource {
       public static final int SUCCESS = 201;
       public static final String PATH = "/{" + PathParameters.REQUEST_ID + "}";
       public static final String RELATIVE_PATH = PATH;
-      public static final String FULL_PATH = MsisdnResource.PATH + RELATIVE_PATH;
+      public static final String FULL_PATH = VouchersResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REQUEST_ID = "requestId";
@@ -72,7 +72,7 @@ public abstract class VouchersResource {
       public static final String PATH =
             "/{" + PathParameters.REQUEST_ID + "}/reversals/{" + PathParameters.REVERSAL_ID + "}";
       public static final String RELATIVE_PATH = PATH;
-      public static final String FULL_PATH = MsisdnResource.PATH + RELATIVE_PATH;
+      public static final String FULL_PATH = VouchersResource.PATH + RELATIVE_PATH;
 
       public class PathParameters {
          public static final String REVERSAL_ID = "reversalId";


### PR DESCRIPTION
They were previously pointing to the MSISDN resource instead of the
Vouchers resource.