### PR TITLE
Implemented new service-interface-base interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>airtime-service-interface</artifactId>
-    <version>5.13.2</version>
+    <version>5.14.0</version>
 </dependency>
 <dependency>
       <groupId>io.electrum</groupId>
       <artifactId>service-interface-base</artifactId>
-      <version>3.23.0</version>
+      <version>3.24.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
       <groupId>io.electrum</groupId>
       <artifactId>service-interface-base</artifactId>
-      <version>3.24.0</version>
+      <version>3.26.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include the service interface into your maven project, include the below depe
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>airtime-service-interface</artifactId>
-    <version>5.14.0</version>
+    <version>5.15.0</version>
 </dependency>
 <dependency>
       <groupId>io.electrum</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <service-interface-base-version>3.23.0</service-interface-base-version>
+    <service-interface-base-version>3.24.0-SNAPSHOT</service-interface-base-version>
     <jetty-version>9.4.17.v20190418</jetty-version>
     <jersey-version>2.22.1</jersey-version>
     <hibernate-validator-version>5.2.2.Final</hibernate-validator-version>
@@ -42,8 +42,8 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
-    <minor-version>13</minor-version>
-    <patch-version>2</patch-version>
+    <minor-version>14</minor-version>
+    <patch-version>0-SNAPSHOT</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
-    <minor-version>14</minor-version>
+    <minor-version>15</minor-version>
     <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
-    <minor-version>13</minor-version>
-    <patch-version>3</patch-version>
+    <minor-version>14</minor-version>
+    <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -4,7 +4,16 @@ This page describes changes to the Airtime Service Interface implemented across 
 
 Released 21 July 2020
 
-- Incorporated Interfaces for Amounts & PaymentMethods from ``service-interface-base``. Core API remains unchanged.
+- This change affects the Java implementation of the API only and does not change the public definition of the API. The Java implementation has been updated as follows:
+  - The following classes now implement the `HasAmounts` interface defined in the base API:
+    - `MsisdnInfoResponse`
+    - `PurchaseRequest`
+    - `PurchaseResponse`
+    - `VoucherRequest`
+    - `VoucherResponse`
+  - The following classes now implement the `HasPaymentMethods` interface defined in the base API:
+    - `PurchaseRequest`
+    - `VoucherRequest`
 
 ## v5.13.3
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,11 @@
 This page describes changes to the Airtime Service Interface implemented across different releases of the interface.
 
+## v5.14.0
+
+Released 30 April 2020
+
+- Incorporated Interfaces for Amounts & PaymentMethods from ``service-interface-base``. Core API remains unchanged.
+
 ## v5.13.2
 
 Released 28 November 2019

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,8 +1,8 @@
 This page describes changes to the Airtime Service Interface implemented across different releases of the interface.
 
-## v5.14.0
+## v5.15.0
 
-Released 21 July 2020
+Released 24 July 2020
 
 - This change affects the Java implementation of the API only and does not change the public definition of the API. The Java implementation has been updated as follows:
   - The following classes now implement the `HasAmounts` interface defined in the base API:

--- a/src/main/java/io/electrum/airtime/api/model/MsisdnInfoResponse.java
+++ b/src/main/java/io/electrum/airtime/api/model/MsisdnInfoResponse.java
@@ -8,6 +8,7 @@ import javax.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -17,7 +18,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "Information about the Msisdn.")
-public class MsisdnInfoResponse {
+public class MsisdnInfoResponse implements HasAmounts {
 
    private Msisdn msisdn;
    private Amounts amounts = null;

--- a/src/main/java/io/electrum/airtime/api/model/PurchaseRequest.java
+++ b/src/main/java/io/electrum/airtime/api/model/PurchaseRequest.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
+import io.electrum.vas.interfaces.HasPaymentMethods;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.PaymentMethod;
 import io.electrum.vas.model.Tender;
@@ -21,7 +23,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "A request for an airtime product. This may be for airtime, data or SMS products or a combination. Airtime requests may be for PIN based or PIN-less products.")
-public class PurchaseRequest extends Transaction {
+public class PurchaseRequest extends Transaction implements HasAmounts, HasPaymentMethods {
 
    private Amounts amounts = null;
    private Product product = null;

--- a/src/main/java/io/electrum/airtime/api/model/PurchaseResponse.java
+++ b/src/main/java/io/electrum/airtime/api/model/PurchaseResponse.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.SlipData;
 import io.electrum.vas.model.Transaction;
@@ -19,7 +20,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "A response to a successful request for an airtime product.")
-public class PurchaseResponse extends Transaction {
+public class PurchaseResponse extends Transaction implements HasAmounts {
 
    private Amounts amounts = null;
    private Product product = null;

--- a/src/main/java/io/electrum/airtime/api/model/VoucherRequest.java
+++ b/src/main/java/io/electrum/airtime/api/model/VoucherRequest.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
+import io.electrum.vas.interfaces.HasPaymentMethods;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.PaymentMethod;
 import io.electrum.vas.model.Tender;
@@ -20,7 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "Information about the voucher provision request.")
-public class VoucherRequest extends Transaction {
+public class VoucherRequest extends Transaction implements HasAmounts, HasPaymentMethods {
 
    private Amounts amounts = null;
    private Product product = null;

--- a/src/main/java/io/electrum/airtime/api/model/VoucherResponse.java
+++ b/src/main/java/io/electrum/airtime/api/model/VoucherResponse.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.electrum.vas.Utils;
+import io.electrum.vas.interfaces.HasAmounts;
 import io.electrum.vas.model.Amounts;
 import io.electrum.vas.model.Institution;
 import io.electrum.vas.model.SlipData;
@@ -18,7 +19,7 @@ import io.swagger.annotations.ApiModelProperty;
  **/
 
 @ApiModel(description = "Information about the voucher provisioned.")
-public class VoucherResponse extends Transaction {
+public class VoucherResponse extends Transaction implements HasAmounts {
 
    private Amounts amounts = null;
    private Product responseProduct = null;


### PR DESCRIPTION
> We want to be able to implement logic that can do payment orchestration for both Airtime and PPU messages polymorphically.

We have added `HasAmounts` & `HasPaymentMethods` interfaces' in service-interface-base in order to solve the above problem statement. This PR simply pulls these changes into the airtime-service-interface.

Imports have changed in the modified files to conform to Electrums Eclipse Code Formatter profile. Please let me know if I should change it back. Note, too, the minor version bump due to the reliance on these new interfaces.