### PR TITLE
Update interface to publish to Sonatype OSSRH nexus repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,16 @@ jobs:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh -Possrh
       - run:
-          name: Release to Sonatype OSSRH
-          command: /electrum/bin/releaseToOssrh.sh
-      - run:
           name: Deploy docs to Github Pages
           command: /electrum/bin/deployGithubPages.sh ~/project/target/devguide/site
       - run:
-          name: Release failed! Revert OSSRH release steps that might have been taken
+          name: Deploy release to Sonatype OSSRH
+          command: /electrum/bin/releaseToOssrh.sh
+      - run:
+          name: Release from Sonatype OSSRH to Maven Central
+          command: /electrum/bin/releaseToMavenCentral.sh
+      - run:
+          name: Release failed! Revert OSSRH release steps that might have been taken.
           command: /electrum/bin/revertReleaseOssrh.sh
           when: on_fail
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: /electrum/bin/importGpgSecret.sh
       - run:
           name: Compile, Test, and Release
-          command: /electrum/bin/simpleTestAndReleaseJava.sh
+          command: /electrum/bin/simpleTestAndReleaseJava.sh -Possrh
       - run:
           name: Release to Sonatype OSSRH
           command: /electrum/bin/releaseToOssrh.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Configure GPG private key for signing project artifacts in OSS Sonatype
           command: >
-           echo $SECRING_GPG_ASC_BASE64 | gpg --batch --armour --no-tty --import --yes
+           echo $SECRING_GPG_ASC | gpg --batch --armour --no-tty --import --yes
       - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Configure GPG private key for signing project artifacts in OSS Sonatype
           command: >
-           echo $SECRING_GPG_ASC_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
+           echo $SECRING_GPG_ASC_BASE64 | gpg --batch --armour --no-tty --import --yes
       - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,9 @@ workflows:
   commit:
     jobs:
       - build-and-release:
-          context: java
+          context:
+            - java
+            - oss
       - code-coverage-report:
           context: java
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,17 +27,20 @@ jobs:
           name: Validate release type
           command: /electrum/bin/validateReleaseType.sh
       - run:
+          name: Import PGP secret keyring
+          command: /electrum/bin/importGpgSecret.sh
+      - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh
+      - run:
+          name: Release OSS to nexus
+          command: /electrum/bin/releaseToOssrh.sh
       - run:
           name: Deploy docs to Github Pages
           command: /electrum/bin/deployGithubPages.sh ~/project/target/devguide/site
       - run:
-          name: Deploy to Sonatype OSSRH
-          command: /electrum/bin/deployOss.sh
-      - run:
           name: Release failed! Revert any release steps that might have been taken
-          command: /electrum/bin/revertReleaseJava.sh
+          command: /electrum/bin/revertReleaseJava.sh && /electrum/bin/revertReleaseOssrh.sh
           when: on_fail
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: /electrum/bin/importGpgSecret.sh
       - run:
           name: Compile, Test, and Release
-          command: /electrum/bin/simpleTestAndReleaseJava.sh
+          command: /electrum/bin/simpleTestAndReleaseJava.sh -Possrh
       - run:
           name: Release to Sonatype OSSRH
           command: /electrum/bin/releaseToOssrh.sh
@@ -39,8 +39,12 @@ jobs:
           name: Deploy docs to Github Pages
           command: /electrum/bin/deployGithubPages.sh ~/project/target/devguide/site
       - run:
+          name: Release failed! Revert OSSRH release steps that might have been taken
+          command: /electrum/bin/revertReleaseOssrh.sh
+          when: on_fail
+      - run:
           name: Release failed! Revert any release steps that might have been taken
-          command: /electrum/bin/revertReleaseJava.sh; /electrum/bin/revertReleaseOssrh.sh
+          command: /electrum/bin/revertReleaseJava.sh
           when: on_fail
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,14 @@ jobs:
           name: Validate release type
           command: /electrum/bin/validateReleaseType.sh
       - run:
-          name: Configure GPG private key for signing project artifacts in OSS Sonatype
-          command: >
-           echo "$SECRING_GPG_ASC" | gpg --batch --armour --no-tty --import --yes
-      - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh
       - run:
           name: Deploy docs to Github Pages
           command: /electrum/bin/deployGithubPages.sh ~/project/target/devguide/site
+      - run:
+          name: Deploy to Sonatype OSSRH
+          command: /electrum/bin/deployOss.sh
       - run:
           name: Release failed! Revert any release steps that might have been taken
           command: /electrum/bin/revertReleaseJava.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-release:
     docker:
-      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk:11.0.4-SNAPSHOT
+      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk
         auth:
           username: $ARTIFACTORY_READER_USERNAME
           password: $ARTIFACTORY_READER_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,14 @@ jobs:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh
       - run:
-          name: Release OSS to nexus
+          name: Release to Sonatype OSSRH
           command: /electrum/bin/releaseToOssrh.sh
       - run:
           name: Deploy docs to Github Pages
           command: /electrum/bin/deployGithubPages.sh ~/project/target/devguide/site
       - run:
           name: Release failed! Revert any release steps that might have been taken
-          command: /electrum/bin/revertReleaseJava.sh && /electrum/bin/revertReleaseOssrh.sh
+          command: /electrum/bin/revertReleaseJava.sh; /electrum/bin/revertReleaseOssrh.sh
           when: on_fail
       - run:
           name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Configure GPG private key for signing project artifacts in OSS Sonatype
           command: >
-           echo $SECRING_GPG_ASC | gpg --batch --armour --no-tty --import --yes
+           echo "$SECRING_GPG_ASC" | gpg --batch --armour --no-tty --import --yes
       - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,10 @@ jobs:
           name: Validate release type
           command: /electrum/bin/validateReleaseType.sh
       - run:
+          name: Configure GPG private key for signing project artifacts in OSS Sonatype
+          command: >
+           echo $SECRING_GPG_ASC_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
+      - run:
           name: Compile, Test, and Release
           command: /electrum/bin/simpleTestAndReleaseJava.sh
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: /electrum/bin/importGpgSecret.sh
       - run:
           name: Compile, Test, and Release
-          command: /electrum/bin/simpleTestAndReleaseJava.sh -Possrh
+          command: /electrum/bin/simpleTestAndReleaseJava.sh
       - run:
           name: Release to Sonatype OSSRH
           command: /electrum/bin/releaseToOssrh.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-release:
     docker:
-      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk
+      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk:11.0.4-SNAPSHOT
         auth:
           username: $ARTIFACTORY_READER_USERNAME
           password: $ARTIFACTORY_READER_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>${nexus-staging-maven-plugin-version}</version>
+<!--        <version>${nexus-staging-maven-plugin-version}</version>-->
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-RC1</version>
+  <version>${major-version}.${minor-version}.${patch-version}-RC2</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>
@@ -413,9 +413,9 @@
       </build>
     </profile>
     <profile>
-      <id>deployOss</id>
+      <id>ossrh</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.github.dcendents/android-maven-gradle-plugin -->
+    <dependency>
+      <groupId>com.github.dcendents</groupId>
+      <artifactId>android-maven-gradle-plugin</artifactId>
+      <version>2.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -231,11 +237,6 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
-          </dependency>
-          <dependency>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin-version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-RC4</version>
+  <version>${major-version}.${minor-version}.${patch-version}</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <skipRemoteStaging>true</skipRemoteStaging>
               <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
               <autoReleaseAfterClose>false</autoReleaseAfterClose>
             </configuration>
@@ -459,4 +460,10 @@
       </build>
     </profile>
   </profiles>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
       </build>
     </profile>
     <profile>
-      <id>ossDeploy</id>
+      <id>deployOss</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/com.github.dcendents/android-maven-gradle-plugin -->
-    <dependency>
-      <groupId>com.github.dcendents</groupId>
-      <artifactId>android-maven-gradle-plugin</artifactId>
-      <version>2.1</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -422,17 +416,17 @@
           </execution>
         </executions>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>org.sonatype.plugins</groupId>-->
-<!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--        <version>${nexus-staging-maven-plugin-version}</version>-->
-<!--        <extensions>true</extensions>-->
-<!--        <configuration>-->
-<!--          <serverId>ossrh</serverId>-->
-<!--          <nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
-<!--          <autoReleaseAfterClose>false</autoReleaseAfterClose>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>${nexus-staging-maven-plugin-version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
     <profile>
       <id>ossrh</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -422,17 +422,17 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>${nexus-staging-maven-plugin-version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.sonatype.plugins</groupId>-->
+<!--        <artifactId>nexus-staging-maven-plugin</artifactId>-->
+<!--        <version>${nexus-staging-maven-plugin-version}</version>-->
+<!--        <extensions>true</extensions>-->
+<!--        <configuration>-->
+<!--          <serverId>ossrh</serverId>-->
+<!--          <nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
+<!--          <autoReleaseAfterClose>false</autoReleaseAfterClose>-->
+<!--        </configuration>-->
+<!--      </plugin>-->
     </plugins>
   </build>
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
       <organizationUrl>http://electrum.io</organizationUrl>
     </developer>
   </developers>
+
   <scm>
     <connection>scm:git:git@github.com:electrumpayments/airtime-service-interface.git</connection>
     <developerConnection>scm:git:git@github.com:electrumpayments/airtime-service-interface.git</developerConnection>
@@ -277,8 +278,11 @@
             </goals>
             <configuration>
               <publisher>
+                <!--suppress UnresolvedMavenProperty -->
                 <contextUrl>${artifactory-url}/</contextUrl>
+                <!--suppress UnresolvedMavenProperty -->
                 <username>${artifactory-username}</username>
+                <!--suppress UnresolvedMavenProperty -->
                 <password>${artifactory-password}</password>
                 <repoKey>oss-local</repoKey>
               </publisher>
@@ -396,39 +400,54 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${maven-gpg-plugin-version}</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-            <configuration>
-              <gpgArguments>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>${nexus-staging-maven-plugin-version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven-gpg-plugin-version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${nexus-staging-maven-plugin-version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <!--suppress UnresolvedMavenProperty -->
+        <keyname>${gpgKeyName}</keyname>
+        <!--suppress UnresolvedMavenProperty -->
+        <passphraseServerId>${gpgKeyName}</passphraseServerId>
+      </properties>
+    </profile>
+  </profiles>
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
     <profile>
       <id>ossrh</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -266,31 +266,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.jfrog.buildinfo</groupId>
-        <artifactId>artifactory-maven-plugin</artifactId>
-        <version>2.6.1</version>
-        <inherited>false</inherited>
-        <executions>
-          <execution>
-            <id>build-info</id>
-            <goals>
-              <goal>publish</goal>
-            </goals>
-            <configuration>
-              <publisher>
-                <!--suppress UnresolvedMavenProperty -->
-                <contextUrl>${artifactory-url}/</contextUrl>
-                <!--suppress UnresolvedMavenProperty -->
-                <username>${artifactory-username}</username>
-                <!--suppress UnresolvedMavenProperty -->
-                <password>${artifactory-password}</password>
-                <repoKey>oss-local</repoKey>
-              </publisher>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
@@ -404,7 +379,45 @@
   </build>
   <profiles>
     <profile>
-      <id>ossrh</id>
+      <id>publishArtifacts</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jfrog.buildinfo</groupId>
+            <artifactId>artifactory-maven-plugin</artifactId>
+            <version>2.6.1</version>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>build-info</id>
+                <goals>
+                  <goal>publish</goal>
+                </goals>
+                <configuration>
+                  <publisher>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <contextUrl>${artifactory-url}/</contextUrl>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <username>${artifactory-username}</username>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <password>${artifactory-password}</password>
+                    <repoKey>oss-local</repoKey>
+                  </publisher>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>ossDeploy</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -423,6 +436,10 @@
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>
+                  <!--suppress UnresolvedMavenProperty -->
+                  <keyname>${gpgKeyName}</keyname>
+                  <!--suppress UnresolvedMavenProperty -->
+                  <passphraseServerId>${gpgKeyName}</passphraseServerId>
                 </configuration>
               </execution>
             </executions>
@@ -440,12 +457,6 @@
           </plugin>
         </plugins>
       </build>
-      <properties>
-        <!--suppress UnresolvedMavenProperty -->
-        <keyname>${gpgKeyName}</keyname>
-        <!--suppress UnresolvedMavenProperty -->
-        <passphraseServerId>${gpgKeyName}</passphraseServerId>
-      </properties>
     </profile>
   </profiles>
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-SNAPSHOT</version>
+  <version>${major-version}.${minor-version}.${patch-version}-RC1</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>
@@ -26,7 +26,6 @@
       <organizationUrl>http://electrum.io</organizationUrl>
     </developer>
   </developers>
-
   <scm>
     <connection>scm:git:git@github.com:electrumpayments/airtime-service-interface.git</connection>
     <developerConnection>scm:git:git@github.com:electrumpayments/airtime-service-interface.git</developerConnection>
@@ -43,8 +42,8 @@
     <swagger-maven-plugin-version>3.1.3</swagger-maven-plugin-version>
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
-    <minor-version>22</minor-version>
-    <patch-version>1</patch-version>
+    <minor-version>23</minor-version>
+    <patch-version>0</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml
@@ -381,7 +380,7 @@
     <profile>
       <id>publishArtifacts</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <build>
         <plugins>
@@ -416,7 +415,7 @@
     <profile>
       <id>deployOss</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>
@@ -452,6 +451,7 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
               <autoReleaseAfterClose>false</autoReleaseAfterClose>
             </configuration>
           </plugin>
@@ -459,10 +459,4 @@
       </build>
     </profile>
   </profiles>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}</version>
+  <version>${major-version}.${minor-version}.${patch-version}-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>
@@ -43,11 +43,13 @@
     <logback-version>1.0.13</logback-version>
     <major-version>5</major-version>
     <minor-version>22</minor-version>
-    <patch-version>0</patch-version>
+    <patch-version>1</patch-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml
     </sonar.coverage.jacoco.xmlReportPaths>
+    <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
+    <nexus-staging-maven-plugin-version>1.6.8</nexus-staging-maven-plugin-version>
   </properties>
 
   <dependencies>
@@ -394,6 +396,43 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>${maven-gpg-plugin-version}</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>${nexus-staging-maven-plugin-version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-RC2</version>
+  <version>${major-version}.${minor-version}.${patch-version}-RC3</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,11 @@
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
           </dependency>
+          <dependency>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${nexus-staging-maven-plugin-version}</version>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
@@ -419,7 +424,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-<!--        <version>${nexus-staging-maven-plugin-version}</version>-->
+        <version>${nexus-staging-maven-plugin-version}</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-interface</artifactId>
-  <version>${major-version}.${minor-version}.${patch-version}-RC3</version>
+  <version>${major-version}.${minor-version}.${patch-version}-RC4</version>
   <packaging>jar</packaging>
 
   <name>Airtime Service Interface</name>
@@ -265,6 +265,28 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.jfrog.buildinfo</groupId>
+        <artifactId>artifactory-maven-plugin</artifactId>
+        <version>2.6.1</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>build-info</id>
+            <goals>
+              <goal>publish</goal>
+            </goals>
+            <configuration>
+              <publisher>
+                <contextUrl>${artifactory-url}/</contextUrl>
+                <username>${artifactory-username}</username>
+                <password>${artifactory-password}</password>
+                <repoKey>oss-local</repoKey>
+              </publisher>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
@@ -378,41 +400,6 @@
   </build>
   <profiles>
     <profile>
-      <id>publishArtifacts</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jfrog.buildinfo</groupId>
-            <artifactId>artifactory-maven-plugin</artifactId>
-            <version>2.6.1</version>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>build-info</id>
-                <goals>
-                  <goal>publish</goal>
-                </goals>
-                <configuration>
-                  <publisher>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <contextUrl>${artifactory-url}/</contextUrl>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <username>${artifactory-username}</username>
-                    <!--suppress UnresolvedMavenProperty -->
-                    <password>${artifactory-password}</password>
-                    <repoKey>oss-local</repoKey>
-                  </publisher>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>ossrh</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -460,10 +447,4 @@
       </build>
     </profile>
   </profiles>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 </project>

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,11 @@
 This page describes changes to the Airtime Service Interface implemented across different releases of the interface.
 
+## v5.23.0
+Release 16 February 2021
+
+- Artefacts are now deployed directly to Soatype OSSRH as opposed to JCenter. The artefacts
+  are signed with Electrum Payments' GPG key.
+
 ## v5.22.0
 Released 11 February 2021
 

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,7 +1,7 @@
 This page describes changes to the Airtime Service Interface implemented across different releases of the interface.
 
 ## v5.23.0
-Release 16 February 2021
+Release 22 February 2021
 
 - Artefacts are now deployed directly to Soatype OSSRH as opposed to JCenter. The artefacts
   are signed with Electrum Payments' GPG key.


### PR DESCRIPTION
Release to both Artifactory and Sonatype OSSRH nexus repository. The manual release from Artifactory to Bintray step is no longer required.

Require the Circleci `oss` context which has the following environment variables
* `GPG_KEY_FINGERPRINT`, `GPG_PASSPHRASE`, and `GPG_SECRING_ASC_BASE64` used to sign the OSS files
* `SERVER_OSSRH_PASSWORD`, and `SERVER_OSSRH_USERNAME`, containing the nexus deeds